### PR TITLE
Added Quat_FromPitchYawRoll() helper function.

### DIFF
--- a/include/c3d/maths.h
+++ b/include/c3d/maths.h
@@ -668,4 +668,16 @@ static inline C3D_FVec FVec3_CrossQuat(C3D_FVec v, C3D_FQuat q)
 	// v×q = q^-1×v
 	return Quat_CrossFVec3(Quat_Inverse(q), v);
 }
+
+/**
+ * @brief Converting Pitch, Yaw, and Roll to Quaternion equivalent
+ * @param[in] pitch      The pitch angle in radians.
+ * @param[in] yaw        The yaw angle in radians.
+ * @param[in] roll       The roll angle in radians.
+ * @return    C3D_FQuat  The Quaternion equivalent with the pitch, yaw, and roll orientations applied.
+ */
+static inline C3D_FQuat Quat_FromPitchYawRoll(float pitch, float yaw, float roll)
+{
+	return Quat_RotateZ(Quat_RotateY(Quat_RotateX(Quat_Identity(), pitch, false), yaw, false), roll, false);
+}
 ///@}

--- a/include/c3d/maths.h
+++ b/include/c3d/maths.h
@@ -676,8 +676,5 @@ static inline C3D_FVec FVec3_CrossQuat(C3D_FVec v, C3D_FQuat q)
  * @param[in] roll       The roll angle in radians.
  * @return    C3D_FQuat  The Quaternion equivalent with the pitch, yaw, and roll orientations applied.
  */
-static inline C3D_FQuat Quat_FromPitchYawRoll(float pitch, float yaw, float roll)
-{
-	return Quat_RotateZ(Quat_RotateY(Quat_RotateX(Quat_Identity(), pitch, false), yaw, false), roll, false);
-}
+C3D_FQuat Quat_FromPitchYawRoll(float pitch, float yaw, float roll, bool bRightSide);
 ///@}

--- a/source/maths/quat_frompitchyawroll.c
+++ b/source/maths/quat_frompitchyawroll.c
@@ -1,0 +1,28 @@
+#include <c3d/maths.h>
+
+C3D_FQuat Quat_FromPitchYawRoll(float pitch, float yaw, float roll, bool bRightSide)
+{
+	float pitch_c = cosf(pitch / 2.0f);
+	float pitch_s = sinf(pitch / 2.0f);
+	float yaw_c = cosf(yaw / 2.0f);
+	float yaw_s = sinf(yaw / 2.0f);
+	float roll_c = cosf(roll / 2.0f);
+	float roll_s = sinf(roll / 2.0f);
+
+	if (bRightSide)
+	{
+		return Quat_New(
+			pitch_s * yaw_c * roll_c - pitch_c * yaw_s * roll_s,
+			pitch_c * yaw_s * roll_c + pitch_s * yaw_c * roll_s,
+			pitch_c * yaw_c * roll_s - pitch_s * yaw_s * roll_c,
+			pitch_c * yaw_c * roll_c + pitch_s * yaw_s * roll_s);
+	}
+	else
+	{
+		return Quat_New(
+			pitch_s * yaw_c * roll_c + pitch_c * yaw_s * roll_s,
+			pitch_c * yaw_s * roll_c - pitch_s * yaw_c * roll_s,
+			pitch_c * yaw_c * roll_s + pitch_s * yaw_s * roll_c,
+			pitch_c * yaw_c * roll_c - pitch_s * yaw_s * roll_s);
+	}
+}


### PR DESCRIPTION
Quickly converts pitch, yaw, and roll rotations to the Quaternion equivalent orientation.

Inspired from [Microsoft](https://msdn.microsoft.com/en-us/library/bb463942.aspx?f=255&MSPPError=-2147217396).